### PR TITLE
Fix bug: ParserBase has no virtual destructor.

### DIFF
--- a/cppexpat.hpp
+++ b/cppexpat.hpp
@@ -67,7 +67,7 @@ namespace cppexpat {
     public:
         //\cond HIDDEN
         ParserBase();
-        ~ParserBase() { XML_ParserFree(p); }
+        virtual ~ParserBase() { XML_ParserFree(p); }
         //\endcond
         //! Parse an input stream.
         void parse(std::istream& f, int sz);


### PR DESCRIPTION
The destructor of `ParserBase` frees the expat parser. If this
destructor is non-virtual, the destruction of a derived parser does not
clean up properly.
